### PR TITLE
Fixed bug when pressing tab on an empty string in the ETGModConsole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Jetbrains Rider project directory
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Assembly-CSharp.Base.mm/src/ETGGUI/ETGModConsole.cs
+++ b/Assembly-CSharp.Base.mm/src/ETGGUI/ETGModConsole.cs
@@ -317,7 +317,7 @@ public class ETGModConsole : ETGModMenu {
 		*/
 
         string matchkeyword = string.Empty;
-        if (!inputtext.EndsWithInvariant(" ")) {
+        if (!inputtext.EndsWithInvariant(" ") && inputtext.Length > 0) {
             matchindex--;
             matchkeyword = input[input.Length - 1];
         }


### PR DESCRIPTION
(Also added .idea to the .gitignore)

To be honest, i didn't test it with a build of ETG, because i didn't want the hassle of learning that pipeline.
I just did the exact same thing in dnSpy and it  seemed to work.
Instead of the exception the log says this now: `ETGModConsole: no completions available (match returned null)`